### PR TITLE
Added Meson build script

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,34 @@
+project('Q-Number (Q16.16, signed) library', 'c',
+        version: '0.9.2', license: 'Unlicense',
+        default_options: ['c_std=c99'])
+
+q_inc = include_directories('.')
+
+q_c_args = ['-DQVERSION=0x000902']
+
+cc = meson.get_compiler('c')
+if cc.has_argument('-fwrapv')
+    q_c_args += ['-fwrapv']
+endif
+
+q_lib = static_library('q',
+    files('q.c'),
+    include_directories: q_inc,
+    c_args: q_c_args,
+)
+q_dep = declare_dependency(
+    link_whole: q_lib,
+    include_directories: q_inc
+)
+
+q_expr_exe = executable('expr',
+    files('expr.c'),
+    dependencies: q_dep
+)
+test('expr', q_expr_exe)
+
+q_test_exe = executable('t',
+    files('t.c'),
+    dependencies: q_dep
+)
+test('t', q_test_exe, args: join_paths(meson.current_source_dir(), 't.q'))

--- a/q.c
+++ b/q.c
@@ -123,7 +123,7 @@ inline d_t arshift(const d_t v, const unsigned p) {
 	return leading | (vn >> p);
 }
 
-inline d_t divn(const d_t v, const unsigned p) {
+static inline d_t divn(const d_t v, const unsigned p) {
 	/* return v / (1l << p); */
 	const u_t shifted = ((u_t)v) >> p;
 	if (qispositive(v))


### PR DESCRIPTION
Hi! I'm willing to link to this library from a project built with the [Meson build system](https://mesonbuild.com/).

I added the `meson.build` script to let this library be imported as a [Meson subproject](https://mesonbuild.com/Subprojects.html#using-a-subproject).


### Local Setup and Test

Within the root of this library (e.g. `/home/user/q`), run the following shell commands:

```sh
rm -rf builddir
meson setup builddir
meson test -C builddir
```

Example output for the `test` command:

```
ninja: Entering directory `/home/user/q/builddir'
[6/6] Linking target expr
1/2 t           OK              0.00s
2/2 expr        OK              0.01s


Ok:                 2   
Expected Fail:      0   
Fail:               0   
Unexpected Pass:    0   
Skipped:            0   
Timeout:            0   

Full log written to /home/user/q/builddir/meson-logs/testlog.txt
```


### Subproject via Meson Wrap

You can import the project via [Meson Wrap](https://mesonbuild.com/Wrap-dependency-system-manual.html).
The followng example wraps my forked git branch.

FIle `<PROJECT>/subprojects/q.wrap`:

```ini
[wrap-git]
url = https://github.com/TexZK/q.git
revision = meson
depth = 1

[provide]
q = q_dep
```

Executable example snippet from the root `meson.build`:

```py
# [...]
q_sub = subproject('q')
executable('myexe', 'main.c', dependencies: dependency('q'))
# [...]
```


### static inline divn()

Aside from the Meson configuration, I had a tiny compiler annoyance using GCC.
I had to mark `divn()` as `static inline` instead of just `inline` because the linker was upset somehow.
Being everything inside the same compile unit itself, this change is fully backwards compatible.

This was the output of the `meson test` command before the change:

```
ninja: Entering directory `/home/user/q/builddir'
[5/6] Linking target t
FAILED: t 
cc  -o t t.p/t.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--whole-archive -Wl,--start-group libq.a -Wl,--end-group -Wl,--no-whole-archive
/usr/bin/ld: libq.a.p/q.c.o: in function `qdiv':
/home/user/q/builddir/../q.c:277: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o: in function `cordic':
/home/user/q/builddir/../q.c:597: undefined reference to `divn'
/usr/bin/ld: /home/user/q/builddir/../q.c:598: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o: in function `qlog':
/home/user/q/builddir/../q.c:907: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o: in function `qexp':
/home/user/q/builddir/../q.c:919: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o:/home/user/q/builddir/../q.c:941: more undefined references to `divn' follow
collect2: error: ld returned 1 exit status
[6/6] Linking target expr
FAILED: expr 
cc  -o expr expr.p/expr.c.o -Wl,--as-needed -Wl,--no-undefined -Wl,--whole-archive -Wl,--start-group libq.a -Wl,--end-group -Wl,--no-whole-archive
/usr/bin/ld: libq.a.p/q.c.o: in function `qdiv':
/home/user/q/builddir/../q.c:277: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o: in function `cordic':
/home/user/q/builddir/../q.c:597: undefined reference to `divn'
/usr/bin/ld: /home/user/q/builddir/../q.c:598: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o: in function `qlog':
/home/user/q/builddir/../q.c:907: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o: in function `qexp':
/home/user/q/builddir/../q.c:919: undefined reference to `divn'
/usr/bin/ld: libq.a.p/q.c.o:/home/user/q/builddir/../q.c:941: more undefined references to `divn' follow
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
Could not rebuild /home/user/q/builddir
```
